### PR TITLE
Add summary table to claude-react-artifacts.md

### DIFF
--- a/contributors/claude-react-artifacts.md
+++ b/contributors/claude-react-artifacts.md
@@ -1,5 +1,22 @@
 # React Artifact Development Guide for Claude's Renderer
 
+## Rules Table
+
+| Rule ID | Rule Summary |
+| ------- | ------------ |
+| A1      | Do not use form; use div with onClick/onChange instead |
+| A2      | Do not use import aliases; use direct imports or wrapper components |
+| A3      | No trailing commas, empty lines, or comments inside import blocks |
+| A4      | Do not use browser storage APIs; keep state in React only |
+| A5      | Only full Tailwind classes; no dynamic or arbitrary values |
+| A6      | Use only supported libraries (Three r128); CSS-in-JS not supported |
+| A7      | Only console.log, console.warn, and console.error are supported |
+| A8      | Workers, WebSocket, and device/media APIs are blocked |
+| A9      | Use window.fs with async/try-catch; no Node or sync fs |
+| A10     | Default export component; props have defaults; async only in effects |
+
+----
+
 ## Critical Constraints - Will Break Artifacts ⚠️
 
 These constraints are specific to Claude's artifact renderer and will cause complete failure if violated.


### PR DESCRIPTION
Add a summary table to `contributors/claude-react-artifacts.md` for consistency with other contributor files.

---
<a href="https://cursor.com/background-agent?bcId=bc-3b72f226-2fa2-4b00-9e27-7091147122ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3b72f226-2fa2-4b00-9e27-7091147122ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

New Features:
- Introduce a “Rules Table” section with entries A1 through A10 detailing artifact development guidelines